### PR TITLE
Changed the example of SORT function from a quoted list to a fresh one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,7 +1319,7 @@ The below returns (2 4 4) by removing all odd numbers:
 
 ```lisp
 
-(sort '(1 4 2 5 6) #'>)
+(sort (list 1 4 2 5 6) #'>)
 
 ```
 

--- a/readme.org
+++ b/readme.org
@@ -1152,7 +1152,7 @@ The below returns (2 4 4) by removing all odd numbers:
 
 #+begin_src lisp
 
-  (sort '(1 4 2 5 6) #'>)
+  (sort (list 1 4 2 5 6) #'>)
   
 #+end_src
 


### PR DESCRIPTION
Because `sort` is destructive as you said, the consequence is undefined when using it to a literal object (the quoted list, `'(1 4 2 5 6)`, in this case).
This is a minimal fix for avoiding this problem.